### PR TITLE
Dev

### DIFF
--- a/docs/generate_json.py
+++ b/docs/generate_json.py
@@ -1,0 +1,11 @@
+file_obj = open('./docs/tagstoinclude.txt', 'r')
+file_lines = file_obj.readlines()
+file_obj.close()
+output = ''
+for line in file_lines:
+    output += '        {\n'
+    output += '            "include": "#tag-%s.namelist-fcp.pwx"\n'%line[0:-1]
+    output += '        },\n'
+outfile = open('./docs/generated_json.txt','w')
+outfile.write(output)
+outfile.close()

--- a/docs/generated_json.txt
+++ b/docs/generated_json.txt
@@ -1,0 +1,36 @@
+        {
+            "include": "#tag-fcp_mu.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_dynamics.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_conv_thr.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_ndiis.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_mass.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_velocity.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_temperature.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_tempw.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_tolp.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_delta_t.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_nraise.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-freeze_all_atoms.namelist-fcp.pwx"
+        },

--- a/docs/scheme.txt
+++ b/docs/scheme.txt
@@ -1,0 +1,6 @@
+entity name class, entity other attribute --> turquoise (special strings: DFT-D3, smearing, etc)
+entity name tags --> dark blue (namelists and cards)
+constant numeric --> light green (any numeric values)
+constant language bool --> dark blue (anything represents true/false only)
+variable parameter --> light blue (tags)
+string --> brown (for unconstrained string like prefix, pseudopot, etc)

--- a/docs/tags_lists.txt
+++ b/docs/tags_lists.txt
@@ -9,3 +9,6 @@ Hubbard_J(i,ityp)
 
 tags with <tags>(i,j,k) format
 starting_ns_eigenvalue(m,ispin,I)
+
+CONTROL TAGS
+calculation|title|verbosity|restart_mode|wf_collect|nstep|iprint|tstress|tprnfor|dt|outdir|wfcdir|prefix|lkpoint_dir|max_seconds|etot_conv_thr|forc_conv_thr|disk_io|pseudo_dir|tefield|dipfield|lelfield|nberrycyc|lorbm|lberry|gdir|nppstr|lfcp|gate

--- a/docs/tagstoinclude.txt
+++ b/docs/tagstoinclude.txt
@@ -1,0 +1,12 @@
+fcp_mu
+fcp_dynamics
+fcp_conv_thr
+fcp_ndiis
+fcp_mass
+fcp_velocity
+fcp_temperature
+fcp_tempw
+fcp_tolp
+fcp_delta_t
+fcp_nraise
+freeze_all_atoms

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
             "language": "espresso-in",
             "scopeName": "source.espresso-in",
             "path": "./syntaxes/espresso-in.tmLanguage.json"
-        }]
+            },
+            {
+                "path": "./syntaxes/pwx-control-tags.json",
+                "scopeName": "pwx-control-tags.injection",
+                "injectTo": ["source.espresso-in"]
+            }
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,31 @@
                 "path": "./syntaxes/pwx-control-tags.json",
                 "scopeName": "pwx-control-tags.injection",
                 "injectTo": ["source.espresso-in"]
+            },
+            {
+                "path": "./syntaxes/pwx-system-tags.json",
+                "scopeName": "pwx-system-tags.injection",
+                "injectTo": ["source.espresso-in"]
+            },
+            {
+                "path": "./syntaxes/pwx-electrons-tags.json",
+                "scopeName": "pwx-electrons-tags.injection",
+                "injectTo": ["source.espresso-in"]
+            },
+            {
+                "path": "./syntaxes/pwx-ions-tags.json",
+                "scopeName": "pwx-ions-tags.injection",
+                "injectTo": ["source.espresso-in"]
+            },
+            {
+                "path": "./syntaxes/pwx-cell-tags.json",
+                "scopeName": "pwx-cell-tags.injection",
+                "injectTo": ["source.espresso-in"]
+            },
+            {
+                "path": "./syntaxes/pwx-fcp-tags.json",
+                "scopeName": "pwx-fcp-tags.injection",
+                "injectTo": ["source.espresso-in"]
             }
         ]
     }

--- a/syntaxes/espresso-in.tmLanguage.json
+++ b/syntaxes/espresso-in.tmLanguage.json
@@ -3,6 +3,12 @@
 	"name": "QE Input",
 	"patterns": [
 		{
+			"include": "#namelist-control"
+		},
+		{
+			"include": "#card-atomic_species"
+		},
+		{
 			"include": "#namelists"
 		},
 		{
@@ -19,6 +25,30 @@
 		}
 	],
 	"repository": {
+		"namelist-control": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)CONTROL\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-control.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-control.pwx.espresso-in"
+			}]
+		},
+		"card-atomic_species": {
+			"patterns": [{
+				"begin": "^\\s*(?i)atomic_species\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-atomic_species.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\d*\\.?\\d*)(\\s+)(.+)(\\s*$)",
+				"whileCaptures": {
+					"2": { "name": "entity.other.attribute.atom-symbol.card-atomic_species.pwx.espresso-in" },
+					"4": { "name": "constant.numeric.atom-mass.card-atomic_species.pwx.espresso-in" },
+					"6": { "name": "string.pseudopot.card-atomic_species.pwx.espresso-in" }
+				}
+			}]
+		},
 		"namelists": {
 			"patterns": [{
 				"name": "entity.name.section.namelist.espresso-in",

--- a/syntaxes/espresso-in.tmLanguage.json
+++ b/syntaxes/espresso-in.tmLanguage.json
@@ -6,16 +6,46 @@
 			"include": "#namelist-control"
 		},
 		{
+			"include": "#namelist-system"
+		},
+		{
+			"include": "#namelist-electrons"
+		},
+		{
+			"include": "#namelist-ions"
+		},
+		{
+			"include": "#namelist-cell"
+		},
+		{
+			"include": "#namelist-fcp"
+		},
+		{
 			"include": "#card-atomic_species"
 		},
 		{
 			"include": "#card-atomic_positions"
 		},
 		{
+			"include": "#card-k_points"
+		},
+		{
+			"include": "#card-additional_k_points"
+		},
+		{
 			"include": "#card-cell_parameters"
 		},
 		{
-			"include": "#card-k_points"
+			"include": "#card-constraints"
+		},
+		{
+			"include": "#card-occupations"
+		},
+		{
+			"include": "#card-atomic_velocities"
+		},
+		{
+			"include": "#card-atomic_forces"
 		}
 	],
 	"repository": {
@@ -27,6 +57,56 @@
 				},
 				"end": "^\\s*\/\\s*$",
 				"name": "entity.name.tag.content.namelist-control.pwx.espresso-in"
+			}]
+		},
+		"namelist-system": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)SYSTEM\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-system.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-system.pwx.espresso-in"
+			}]
+		},
+		"namelist-electrons": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)ELECTRONS\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-electrons.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-electrons.pwx.espresso-in"
+			}]
+		},
+		"namelist-ions": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)IONS\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-ions.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-ions.pwx.espresso-in"
+			}]
+		},
+		"namelist-cell": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)CELL\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-cell.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-cell.pwx.espresso-in"
+			}]
+		},
+		"namelist-fcp": {
+			"patterns": [{
+				"begin": "^\\s*&(?i)FCP\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.namelist-fcp.pwx.espresso-in" }
+				},
+				"end": "^\\s*\/\\s*$",
+				"name": "entity.name.tag.content.namelist-fcp.pwx.espresso-in"
 			}]
 		},
 		"card-atomic_species": {
@@ -60,6 +140,65 @@
 				}
 			}]
 		},
+		"card-k_points": {
+			"patterns": [
+				{
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(tpiba|crystal|tpiba_b|crystal_b|tpiba_c|crystal_c)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					},
+					"while": "(^\\s*)((\\d+)(\\s*$)|(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\d+\\.?\\d*)(\\s*$))",
+					"whileCaptures": {
+						"3": { "name": "constant.numeric.number-of-k_points.card-k_points.pwx.espresso-in" },
+						"5": { "name": "constant.numeric.k_points-x.card-k_points.pwx.espresso-in" },
+						"7": { "name": "constant.numeric.k_points-y.card-k_points.pwx.espresso-in" },
+						"9": { "name": "constant.numeric.k_points-z.card-k_points.pwx.espresso-in" },
+						"11": { "name": "constant.numeric.k_points-weight.card-k_points.pwx.espresso-in" }
+					}
+				},
+				{
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(automatic)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					},
+					"end": "(^\\s*)(\\d+)(\\s+)(\\d+)(\\s+)(\\d+)(\\s+)([01])(\\s+)([01])(\\s+)([01])(\\s*$)",
+					"endCaptures": {
+						"2": { "name": "constant.numeric.nk1.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"4": { "name": "constant.numeric.nk2.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"6": { "name": "constant.numeric.nk3.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"8": { "name": "entity.other.attribute.shiftk1.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"10": { "name": "entity.other.attribute.shiftk2.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"12": { "name": "entity.other.attribute.shiftk3.monkhorst-pack-grid.card-k_points.pwx.espresso-in" }
+					}
+				},
+				{
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(gamma)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					}
+				}
+			]
+		},
+		"card-additional_k_points": {
+			"patterns": [{
+				"begin": "(^\\s*)((?i)additional_k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(tpiba|crystal|tpiba_b|crystal_b|tpiba_c|crystal_c)(\\}|\\)|))\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-additional_k_points.pwx.espresso-in" },
+					"5": { "name": "entity.other.attribute.type.card-additional_k_points.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)((\\d+)(\\s*$)|(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\d+\\.?\\d*)(\\s*$))",
+				"whileCaptures": {
+					"3": { "name": "constant.numeric.number-of-k_points.card-additional_k_points.pwx.espresso-in" },
+					"5": { "name": "constant.numeric.k_points-x.card-additional_k_points.pwx.espresso-in" },
+					"7": { "name": "constant.numeric.k_points-y.card-additional_k_points.pwx.espresso-in" },
+					"9": { "name": "constant.numeric.k_points-z.card-additional_k_points.pwx.espresso-in" },
+					"11": { "name": "constant.numeric.k_points-weight.card-additional_k_points.pwx.espresso-in" }
+				}
+			}]
+		},
 		"card-cell_parameters": {
 			"patterns": [{
 				"begin": "(^\\s*)((?i)cell_parameters)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\)))(alat|bohr|angstrom)(\\}|\\)))?\\s*$",
@@ -75,43 +214,68 @@
 				}
 			}]
 		},
-		"card-k_points": {
-			"patterns": [
-				{
-					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(tpiba|crystal|tpiba_b|crystal_b|tpiba_c|crystal_c)(\\}|\\)|))\\s*$",
-					"beginCaptures": {
-						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
-						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
-					},
-					"while": "(^\\s*)(\\d*\\s*$|(\\-?\\d*\\.?\\d*)(\\s+)(\\-?\\d*\\.?\\d*)(\\s+)(\\-?\\d*\\.?\\d*)(\\s+)(\\d*\\.?\\d*)(\\s*$))",
-					"whileCaptures": {
-						"2": { "name": "constant.numeric.value.card-k_points.pwx.espresso-in" }
-					}
+		"card-constraints": {
+			"patterns": [{
+				"begin": "(^\\s*)((?i)constraints)\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-constraints.pwx.espresso-in" }
 				},
-				{
-					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(automatic)(\\}|\\)|))\\s*$",
-					"beginCaptures": {
-						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
-						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
-					},
-					"end": "(^\\s*)(\\d+)(\\s+)(\\d+)(\\s+)(\\d+)(\\s+)([01])(\\s+)([01])(\\s+)([01])(\\s*$)",
-					"endCaptures": {
-						"2": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
-						"4": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
-						"6": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
-						"8": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
-						"10": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
-						"12": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" }
-					}
-				},
-				{
-					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(gamma)(\\}|\\)|))\\s*$",
-					"beginCaptures": {
-						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
-						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
-					}
+				"while": "(^\\s*)((\\d+)(\\s+\\{\\s*)(\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*\\}\\s*$)|(?i)(type_coord|atom_coord|distance|planar_angle|torsional_angle|bennet_proj)(\\s+)(\\-?\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s+)(\\-?\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s+\\[\\s*)(\\-?\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s+)(\\-?\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*\\]\\s+\\{\\s*)(\\-?\\d+\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*\\}\\s*$))",
+				"whileCaptures": {
+					"3": { "name": "constant.numeric.nconstr.card-constraints.pwx.espresso-in" },
+					"5": { "name": "constant.numeric.constr_tol.card-constraints.pwx.espresso-in" },
+					"7": { "name": "entity.other.attribute.constr_type.card-constraints.pwx.espresso-in" },
+					"9": { "name": "constant.numeric.constr_1.card-constraints.pwx.espresso-in" },
+					"11": { "name": "constant.numeric.constr_2.card-constraints.pwx.espresso-in" },
+					"13": { "name": "constant.numeric.constr_3.card-constraints.pwx.espresso-in" },
+					"15": { "name": "constant.numeric.constr_4.card-constraints.pwx.espresso-in" },
+					"17": { "name": "constant.numeric.constr_target.card-constraints.pwx.espresso-in" }
 				}
-			]
+			}]
+		},
+		"card-occupations": {
+			"patterns": [{
+				"begin": "(^\\s*)((?i)occupations)\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-occupations.pwx.espresso-in" }
+				},
+				"while": "((^\\s*)(\\d+\\.?\\d*(\\s+\\d+\\.?\\d*){0,9})(\\s*$)|(^\\s*\\[\\s*)(\\d+\\.?\\d*(\\s+\\d+\\.?\\d*){0,9})(\\s*\\]\\s*$))",
+				"whileCaptures": {
+					"3": { "name": "constant.numeric.individual-state.card-occupations.pwx.espresso-in" },
+					"7": { "name": "constant.numeric.minority-spin-state.card-occupations.pwx.espresso-in" }
+				}
+			}]
+		},
+		"card-atomic_velocities": {
+			"patterns": [{
+				"begin": "(^\\s*)((?i)atomic_velocities)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(a\\.u\\.)(\\}|\\)|))\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-atomic_velocities.pwx.espresso-in" },
+					"5": { "name": "entity.other.attribute.unit.card-atomic_velocities.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s*$|\\s+[01]\\s+[01]\\s+[01]\\s*$)",
+				"whileCaptures": {
+					"2": { "name": "entity.other.attribute.atom-symbol.card-atomic_velocities.pwx.espresso-in" },
+					"4": { "name": "constant.numeric.atom-velocity.x-component.card-atomic_velocities.pwx.espresso-in" },
+					"6": { "name": "constant.numeric.atom-velocity.y-component.card-atomic_velocities.pwx.espresso-in" },
+					"8": { "name": "constant.numeric.atom-velocity.z-component.card-atomic_velocities.pwx.espresso-in" }
+				}
+			}]
+		},
+		"card-atomic_forces": {
+			"patterns": [{
+				"begin": "(^\\s*)((?i)atomic_forces)\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-atomic_forces.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s*$|\\s+[01]\\s+[01]\\s+[01]\\s*$)",
+				"whileCaptures": {
+					"2": { "name": "entity.other.attribute.atom-symbol.card-atomic_forces.pwx.espresso-in" },
+					"4": { "name": "constant.numeric.force.x-component.card-atomic_forces.pwx.espresso-in" },
+					"6": { "name": "constant.numeric.force.y-component.card-atomic_forces.pwx.espresso-in" },
+					"8": { "name": "constant.numeric.force.z-component.card-atomic_forces.pwx.espresso-in" }
+				}
+			}]
 		}
 	},
 	"scopeName": "source.espresso-in"

--- a/syntaxes/espresso-in.tmLanguage.json
+++ b/syntaxes/espresso-in.tmLanguage.json
@@ -9,19 +9,13 @@
 			"include": "#card-atomic_species"
 		},
 		{
-			"include": "#namelists"
+			"include": "#card-atomic_positions"
 		},
 		{
-			"include": "#cards"
+			"include": "#card-cell_parameters"
 		},
 		{
-			"include": "#tags"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#strings"
+			"include": "#card-k_points"
 		}
 	],
 	"repository": {
@@ -41,7 +35,7 @@
 				"beginCaptures": {
 					"0": { "name": "entity.name.tag.header.card-atomic_species.pwx.espresso-in" }
 				},
-				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\d*\\.?\\d*)(\\s+)(.+)(\\s*$)",
+				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\d+\\.?\\d*)(\\s+)((?=.*\\w).+)(\\s*$)",
 				"whileCaptures": {
 					"2": { "name": "entity.other.attribute.atom-symbol.card-atomic_species.pwx.espresso-in" },
 					"4": { "name": "constant.numeric.atom-mass.card-atomic_species.pwx.espresso-in" },
@@ -49,77 +43,73 @@
 				}
 			}]
 		},
-		"namelists": {
+		"card-atomic_positions": {
 			"patterns": [{
-				"name": "entity.name.section.namelist.espresso-in",
-				"match": "&\\b(?i)(control|system|electrons|ions|cell|fcp)\\b"
+				"begin": "(^\\s*)((?i)atomic_positions)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\)))(alat|bohr|angstrom|crystal|crystal_sg)(\\}|\\)))?\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-atomic_positions.pwx.espresso-in" },
+					"5": { "name": "entity.other.attribute.unit.card-atomic_positions.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s*$|\\s+[01]\\s+[01]\\s+[01]\\s*$)",
+				"whileCaptures": {
+					"2": { "name": "entity.other.attribute.atom-symbol.card-atomic_positions.pwx.espresso-in" },
+					"4": { "name": "constant.numeric.atom-position.x-component.card-atomic_positions.pwx.espresso-in" },
+					"6": { "name": "constant.numeric.atom-position.y-component.card-atomic_positions.pwx.espresso-in" },
+					"8": { "name": "constant.numeric.atom-position.z-component.card-atomic_positions.pwx.espresso-in" },
+					"9": { "name": "entity.other.attribute.freeze-position.card-atomic_positions.pwx.espresso-in" }
+				}
 			}]
 		},
-		"cards": {
+		"card-cell_parameters": {
 			"patterns": [{
-				"name": "entity.name.section.card.espresso-in",
-				"match": "\\b(?i)(atomic_species|atomic_positions|k_points|cell_parameters|occupations|constraints|atomic_forces)\\b"
+				"begin": "(^\\s*)((?i)cell_parameters)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\)))(alat|bohr|angstrom)(\\}|\\)))?\\s*$",
+				"beginCaptures": {
+					"0": { "name": "entity.name.tag.header.card-cell_parameters.pwx.espresso-in" },
+					"5": { "name": "entity.other.attribute.unit.card-cell_parameters.pwx.espresso-in" }
+				},
+				"while": "(^\\s*)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s+)(\\-?\\d+\\.?\\d*)(\\s*$)",
+				"whileCaptures": {
+					"2": { "name": "constant.numeric.lattice-vector.x-component.card-cell_parameters.pwx.espresso-in" },
+					"4": { "name": "constant.numeric.lattice-vector.y-component-mass.card-cell_parameters.pwx.espresso-in" },
+					"6": { "name": "constant.numeric.lattice-vector.z-component-mass.card-cell_parameters.pwx.espresso-in" }
+				}
 			}]
 		},
-		"tags": {
+		"card-k_points": {
 			"patterns": [
 				{
-				"name": "entity.name.tag.espresso-in",
-				"match": "\\b(calculation|title|verbosity|restart_mode|wf_collect|nstep|iprint|tstress|tprnfor|dt|outdir|wfcdir|prefix|lkpoint_dir|max_seconds|etot_conv_thr|forc_conv_thr|disk_io|pseudo_dir|tefield|dipfield|lelfield|nberrycyc|lorbm|lberry|gdir|nppstr|lfcpopt|monopole|ibrav|A|B|C|cosAB|cosAC|cosBC|nat|ntyp|nbnd|tot_charge|tot_magnetization|ecutwfc|ecutrho|ecutfock|nr1|nr2|nr3|nr1s|nr2s|nr3s|nosym|nosym_evc|noinv|no_t_rev|force_symmorphic|use_all_frac|occupations|one_atom_occupations|starting_spin_angle|degauss|smearing|nspin|noncolin|ecfixed|qcutz|q2sigma|input_dft|exx_fraction|screening_parameter|exxdiv_treatment|x_gamma_extrapolation|ecutvcut|nqx1|nqx2|nqx3|lda_plus_u|lda_plus_u_kind|U_projection_type|edir|emaxpos|eopreg|eamp|constrained_magnetization|lambda|report|lspinorb|assume_isolated|esm_bc|esm_w|esm_efield|esm_nfit|fcp_mu|vdw_corr|london|london_s6|london_rcut|ts_vdw_econv_thr|ts_vdw_isolated|xdm|xdm_a1|xdm_a2|space_group|uniqueb|origin_choice|rhombohedral|zmon|realxz|block|block_1|block_2|block_height|electron_maxstep|scf_must_converge|conv_thr|adaptive_thr|conv_thr_init|conv_thr_multi|mixing_mode|mixing_beta|mixing_ndim|mixing_fixed_ns|diagonalization|ortho_para|diago_thr_init|diago_cg_maxiter|diago_david_ndim|diago_full_acc|efield|efield_phase|startingpot|startingwfc|tqr|ion_dynamics|ion_positions|pot_extrapolation|wfc_extrapolation|remove_rigid_rot|ion_temperature|tempw|tolp|delta_t|nraise|refold_pos|upscale|bfgs_ndim|trust_radius_max|trust_radius_min|trust_radius_ini|w_1|w_2|cell_dynamics|press|wmass|cell_factor|press_conv_thr|cell_dofree)(\\b|\\=)"
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(tpiba|crystal|tpiba_b|crystal_b|tpiba_c|crystal_c)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					},
+					"while": "(^\\s*)(\\d*\\s*$|(\\-?\\d*\\.?\\d*)(\\s+)(\\-?\\d*\\.?\\d*)(\\s+)(\\-?\\d*\\.?\\d*)(\\s+)(\\d*\\.?\\d*)(\\s*$))",
+					"whileCaptures": {
+						"2": { "name": "constant.numeric.value.card-k_points.pwx.espresso-in" }
+					}
 				},
 				{
-					"name": "entity.name.tag.tag-with-1-param.espresso-in",
-					"match": "\\b(celldm|starting_magnetization|Hubbard_U|Hubbard_J0|Hubbard_alpha|Hubbard_beta|angle1|angle2|fixed_magnetization|london_c6|london_rvdw|efield_cart)\\(\\d*\\)"
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(automatic)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					},
+					"end": "(^\\s*)(\\d+)(\\s+)(\\d+)(\\s+)(\\d+)(\\s+)([01])(\\s+)([01])(\\s+)([01])(\\s*$)",
+					"endCaptures": {
+						"2": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"4": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"6": { "name": "constant.numeric.value.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"8": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"10": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" },
+						"12": { "name": "entity.other.attribute.shift.monkhorst-pack-grid.card-k_points.pwx.espresso-in" }
+					}
 				},
 				{
-					"name": "entity.name.tag.tag-with-2-params.espresso-in",
-					"match": "\\b(Hubbard_J)\\(\\d*,\\d*\\)"
-				},
-				{
-					"name": "entity.name.tag.tag-with-3-params.espresso-in",
-					"match": "\\b(starting_ns_eigenvalue)\\(\\d*,\\d*,\\d*\\)"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-					"name": "constant.numeric.espresso-in",
-					"match": "\\b\\d+\\.?(?i)(d-?|d?)\\d*,?\\b"
-				},
-				{
-					"name": "constant.language.bool.espresso-in",
-					"match": "(?i)(\\.true\\.|\\.false\\.)"
-				},
-				{
-					"name": "variable.parameter.atom-type.espresso-in",
-					"match": "\\b(?i)(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og)\\b"
-				},
-				{
-					"name": "variable.parameter.unit.espresso-in",
-					"match": "\\((?i)(alat|bohr|angstrom|crystal|crystal_sg)\\)"
-				},
-				{
-					"name": "variable.parameter.kpoints.espresso-in",
-					"match": "\\b(?i)(tpiba|automatic|crystal|gamma|tpiba_b|crystal_b|tpiba_c|crystal_c)\\b"
-				}
-			]
-		},
-		"strings": {
-			"patterns": [
-				{
-					"name": "string.quoted.single.espresso-in",
-					"begin": "'",
-					"end": "'"
-				},
-				{
-					"name": "string.quoted.double.espresso-in",
-					"begin": "\"",
-					"end": "\""
-				},
-				{
-					"name": "constant.character.escape.espresso-in",
-					"match": "\\\\."
+					"begin": "(^\\s*)((?i)k_points)(\\s(\\{(?=\\w*\\})|\\((?=\\w*\\))|(?![\\{\\(]))(gamma)(\\}|\\)|))\\s*$",
+					"beginCaptures": {
+						"0": { "name": "entity.name.tag.header.card-k_points.pwx.espresso-in" },
+						"5": { "name": "entity.other.attribute.type.card-k_points.pwx.espresso-in" }
+					}
 				}
 			]
 		}

--- a/syntaxes/pwx-cell-tags.json
+++ b/syntaxes/pwx-cell-tags.json
@@ -1,0 +1,98 @@
+{
+    "scopeName": "pwx-cell-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-cell.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-cell_dynamics.namelist-cell.pwx"
+        },
+        {
+            "include": "#tag-press.namelist-cell.pwx"
+        },
+        {
+            "include": "#tag-wmass.namelist-cell.pwx"
+        },
+        {
+            "include": "#tag-cell_factor.namelist-cell.pwx"
+        },
+        {
+            "include": "#tag-press_conv_thr.namelist-cell.pwx"
+        },
+        {
+            "include": "#tag-cell_dofree.namelist-cell.pwx"
+        }
+    ],
+    "repository": {
+        "tag-cell_dynamics.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cell_dynamics)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cell_dynamics.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(none|sd|damp\\-pr|damp\\-w|bfgs|pr|w)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-cell_dynamics.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-press.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(press)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-press.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-press.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-wmass.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(wmass)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-wmass.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-wmass.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-cell_factor.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cell_factor)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cell_factor.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-cell_factor.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-press_conv_thr.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(press_conv_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-press_conv_thr.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-press_conv_thr.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-cell_dofree.namelist-cell.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cell_dofree)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cell_dofree.namelist-cell.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(all|ibrav|x|y|z|xy|xz|yz|xyz|shape|volume|2Dxy|2Dshape|epitaxial_ab|epitaxial_ac|epitaxial_bc)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-cell_dofree.namelist-cell.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}

--- a/syntaxes/pwx-control-tags.json
+++ b/syntaxes/pwx-control-tags.json
@@ -87,7 +87,7 @@
     "repository": {
         "tag-calculation.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(calculation)",
+                "begin": "(^\\s*)(calculation)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-calculation.namelist-control.pwx.espresso-in" }
                 },
@@ -99,11 +99,11 @@
         },
         "tag-title.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(title)",
+                "begin": "(^\\s*)(title)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-title.namelist-control.pwx.espresso-in" }
                 },
-                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "end": "(\\s*\\=\\s*)(\\'(.*)\\')(\\s*,?\\s*)$",
                 "endCaptures": {
                     "2": { "name": "string.quoted.tag-title.namelist-control.pwx.espresso-in" }
                 }
@@ -111,7 +111,7 @@
         },
         "tag-verbosity.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(verbosity)",
+                "begin": "(^\\s*)(verbosity)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-verbosity.namelist-control.pwx.espresso-in" }
                 },
@@ -123,7 +123,7 @@
         },
         "tag-restart_mode.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(restart_mode)",
+                "begin": "(^\\s*)(restart_mode)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-restart_mode.namelist-control.pwx.espresso-in" }
                 },
@@ -135,7 +135,7 @@
         },
         "tag-nstep.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(nstep)",
+                "begin": "(^\\s*)(nstep)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-nstep.namelist-control.pwx.espresso-in" }
                 },
@@ -147,7 +147,7 @@
         },
         "tag-iprint.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(iprint)",
+                "begin": "(^\\s*)(iprint)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-iprint.namelist-control.pwx.espresso-in" }
                 },
@@ -159,7 +159,7 @@
         },
         "tag-tstress.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(tstress)",
+                "begin": "(^\\s*)(tstress)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-tstress.namelist-control.pwx.espresso-in" }
                 },
@@ -171,7 +171,7 @@
         },
         "tag-tprnfor.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(tprnfor)",
+                "begin": "(^\\s*)(tprnfor)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-tprnfor.namelist-control.pwx.espresso-in" }
                 },
@@ -183,11 +183,11 @@
         },
         "tag-dt.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(dt)",
+                "begin": "(^\\s*)(dt)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-dt.namelist-control.pwx.espresso-in" }
                 },
-                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
                 "endCaptures": {
                     "2": { "name": "constant.numeric.tag-dt.namelist-control.pwx.espresso-in" }
                 }
@@ -195,7 +195,7 @@
         },
         "tag-outdir.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(outdir)",
+                "begin": "(^\\s*)(outdir)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-outdir.namelist-control.pwx.espresso-in" }
                 },
@@ -207,7 +207,7 @@
         },
         "tag-wfcdir.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(wfcdir)",
+                "begin": "(^\\s*)(wfcdir)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-wfcdir.namelist-control.pwx.espresso-in" }
                 },
@@ -219,7 +219,7 @@
         },
         "tag-prefix.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(prefix)",
+                "begin": "(^\\s*)(prefix)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-prefix.namelist-control.pwx.espresso-in" }
                 },
@@ -231,11 +231,11 @@
         },
         "tag-max_seconds.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(max_seconds)",
+                "begin": "(^\\s*)(max_seconds)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-max_seconds.namelist-control.pwx.espresso-in" }
                 },
-                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
                 "endCaptures": {
                     "2": { "name": "constant.numeric.tag-max_seconds.namelist-control.pwx.espresso-in" }
                 }
@@ -243,11 +243,11 @@
         },
         "tag-etot_conv_thr.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(etot_conv_thr)",
+                "begin": "(^\\s*)(etot_conv_thr)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-etot_conv_thr.namelist-control.pwx.espresso-in" }
                 },
-                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
                 "endCaptures": {
                     "2": { "name": "constant.numeric.tag-etot_conv_thr.namelist-control.pwx.espresso-in" }
                 }
@@ -255,11 +255,11 @@
         },
         "tag-forc_conv_thr.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(forc_conv_thr)",
+                "begin": "(^\\s*)(forc_conv_thr)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-forc_conv_thr.namelist-control.pwx.espresso-in" }
                 },
-                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
                 "endCaptures": {
                     "2": { "name": "constant.numeric.tag-forc_conv_thr.namelist-control.pwx.espresso-in" }
                 }
@@ -267,7 +267,7 @@
         },
         "tag-disk_io.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(disk_io)",
+                "begin": "(^\\s*)(disk_io)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-disk_io.namelist-control.pwx.espresso-in" }
                 },
@@ -279,7 +279,7 @@
         },
         "tag-pseudo_dir.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(pseudo_dir)",
+                "begin": "(^\\s*)(pseudo_dir)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-pseudo_dir.namelist-control.pwx.espresso-in" }
                 },
@@ -291,7 +291,7 @@
         },
         "tag-tefield.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(tefield)",
+                "begin": "(^\\s*)(tefield)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-tefield.namelist-control.pwx.espresso-in" }
                 },
@@ -303,7 +303,7 @@
         },
         "tag-dipfield.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(dipfield)",
+                "begin": "(^\\s*)(dipfield)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-dipfield.namelist-control.pwx.espresso-in" }
                 },
@@ -315,7 +315,7 @@
         },
         "tag-lelfield.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(lelfield)",
+                "begin": "(^\\s*)(lelfield)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-lelfield.namelist-control.pwx.espresso-in" }
                 },
@@ -327,7 +327,7 @@
         },
         "tag-nberrycyc.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(nberrycyc)",
+                "begin": "(^\\s*)(nberrycyc)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-nberrycyc.namelist-control.pwx.espresso-in" }
                 },
@@ -339,7 +339,7 @@
         },
         "tag-lorbm.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(lorbm)",
+                "begin": "(^\\s*)(lorbm)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-lorbm.namelist-control.pwx.espresso-in" }
                 },
@@ -351,7 +351,7 @@
         },
         "tag-lberry.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(lberry)",
+                "begin": "(^\\s*)(lberry)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-lberry.namelist-control.pwx.espresso-in" }
                 },
@@ -363,7 +363,7 @@
         },
         "tag-gdir.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(gdir)",
+                "begin": "(^\\s*)(gdir)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-gdir.namelist-control.pwx.espresso-in" }
                 },
@@ -375,7 +375,7 @@
         },
         "tag-nppstr.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(nppstr)",
+                "begin": "(^\\s*)(nppstr)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-nppstr.namelist-control.pwx.espresso-in" }
                 },
@@ -387,7 +387,7 @@
         },
         "tag-lfcp.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(lfcp)",
+                "begin": "(^\\s*)(lfcp)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-lfcp.namelist-control.pwx.espresso-in" }
                 },
@@ -399,7 +399,7 @@
         },
         "tag-gate.namelist-control.pwx": {
             "patterns": [{
-                "begin": "(^\\s*)(gate)",
+                "begin": "(^\\s*)(gate)(?=[\\s\\=])",
                 "beginCaptures": {
                     "2": { "name": "variable.parameter.declaration.tag-gate.namelist-control.pwx.espresso-in" }
                 },

--- a/syntaxes/pwx-control-tags.json
+++ b/syntaxes/pwx-control-tags.json
@@ -1,0 +1,413 @@
+{
+    "scopeName": "pwx-control-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-control.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-calculation.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-title.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-verbosity.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-restart_mode.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-nstep.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-iprint.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-tstress.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-tprnfor.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-dt.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-outdir.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-wfcdir.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-prefix.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-max_seconds.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-etot_conv_thr.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-forc_conv_thr.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-disk_io.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-pseudo_dir.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-tefield.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-dipfield.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-lelfield.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-nberrycyc.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-lorbm.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-lberry.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-gdir.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-nppstr.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-lfcp.namelist-control.pwx"
+        },
+        {
+            "include": "#tag-gate.namelist-control.pwx"
+        }
+    ],
+    "repository": {
+        "tag-calculation.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(calculation)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-calculation.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(scf|nscf|bands|relax|md|vc-relax|vc-md)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-calculation.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-title.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(title)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-title.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-title.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-verbosity.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(verbosity)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-verbosity.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(high|low)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-verbosity.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-restart_mode.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(restart_mode)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-restart_mode.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(from_scratch|restart)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-restart_mode.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nstep.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nstep)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nstep.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nstep.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-iprint.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(iprint)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-iprint.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-iprint.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tstress.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tstress)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tstress.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-tstress.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tprnfor.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tprnfor)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tprnfor.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-tprnfor.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dt.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dt)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dt.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-dt.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-outdir.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(outdir)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-outdir.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-outdir.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-wfcdir.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(wfcdir)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-wfcdir.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-wfcdir.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-prefix.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(prefix)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-prefix.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-prefix.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-max_seconds.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(max_seconds)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-max_seconds.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-max_seconds.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-etot_conv_thr.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(etot_conv_thr)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-etot_conv_thr.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-etot_conv_thr.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-forc_conv_thr.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(forc_conv_thr)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-forc_conv_thr.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)d?\\-?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-forc_conv_thr.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-disk_io.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(disk_io)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-disk_io.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(high|medium|low|nowf|none)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-disk_io.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-pseudo_dir.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(pseudo_dir)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-pseudo_dir.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-pseudo_dir.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tefield.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tefield)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tefield.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-tefield.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dipfield.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dipfield)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dipfield.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-dipfield.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lelfield.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lelfield)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lelfield.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lelfield.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nberrycyc.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nberrycyc)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nberrycyc.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nberrycyc.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lorbm.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lorbm)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lorbm.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lorbm.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lberry.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lberry)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lberry.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lberry.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-gdir.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(gdir)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-gdir.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)([1-3])(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-gdir.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nppstr.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nppstr)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nppstr.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nppstr.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lfcp.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lfcp)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lfcp.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lfcp.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-gate.namelist-control.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(gate)",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-gate.namelist-control.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-gate.namelist-control.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}

--- a/syntaxes/pwx-electrons-tags.json
+++ b/syntaxes/pwx-electrons-tags.json
@@ -1,0 +1,370 @@
+{
+    "scopeName": "pwx-electrons-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-electrons.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-electron_maxstep.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-scf_must_converge.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-conv_thr.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-adaptive_thr.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-conv_thr_init.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-conv_thr_multi.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-mixing_mode.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-mixing_beta.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-mixing_ndim.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-mixing_fixed_ns.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diagonalization.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_thr_init.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_cg_maxiter.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_david_ndim.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_full_acc.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_rmm_ndim.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-diago_rmm_conv.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-efield.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-efield_cart.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-efield_phase.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-startingpot.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-startingwfc.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-tqr.namelist-electrons.pwx"
+        },
+        {
+            "include": "#tag-real_space.namelist-electrons.pwx"
+        }
+    ],
+    "repository": {
+        "tag-electron_maxstep.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(electron_maxstep)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-electron_maxstep.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-electron_maxstep.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-scf_must_converge.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(scf_must_converge)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-scf_must_converge.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-scf_must_converge.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-conv_thr.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(conv_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-conv_thr.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-conv_thr.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-adaptive_thr.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(adaptive_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-adaptive_thr.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-adaptive_thr.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-conv_thr_init.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(conv_thr_init)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-conv_thr_init.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-conv_thr_init.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-conv_thr_multi.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(conv_thr_multi)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-conv_thr_multi.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-conv_thr_multi.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-mixing_mode.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(mixing_mode)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-mixing_mode.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(plain|TF|local\\-TF)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-mixing_mode.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-mixing_beta.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(mixing_beta)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-mixing_beta.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-mixing_beta.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-mixing_ndim.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(mixing_ndim)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-mixing_ndim.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-mixing_ndim.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-mixing_fixed_ns.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(mixing_fixed_ns)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-mixing_fixed_ns.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-mixing_fixed_ns.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diagonalization.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diagonalization)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diagonalization.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(david|cg|ppcg|paro|ParO|rmm\\-davidson|rmm\\-paro)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-diagonalization.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_thr_init.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_thr_init)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_thr_init.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-diago_thr_init.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_cg_maxiter.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_cg_maxiter)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_cg_maxiter.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-diago_cg_maxiter.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_david_ndim.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_david_ndim)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_david_ndim.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-diago_david_ndim.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_full_acc.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_full_acc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_full_acc.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-diago_full_acc.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_rmm_ndim.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_rmm_ndim)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_rmm_ndim.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-diago_rmm_ndim.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-diago_rmm_conv.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(diago_rmm_conv)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-diago_rmm_conv.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-diago_rmm_conv.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-efield.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(efield)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-efield.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-efield.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-efield_cart.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(efield_cart\\()([1-3])(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-efield_cart.namelist-electrons.pwx.espresso-in" },
+                    "3": { "name": "entity.other.attribute.vector.tag-efield_cart.namelist-electrons.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-efield_cart.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-efield_cart.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-efield_phase.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(efield_phase)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-efield_phase.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(read|write|none)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-efield_phase.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-startingpot.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(startingpot)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-startingpot.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(atomic|file)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-startingpot.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-startingwfc.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(startingwfc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-startingwfc.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(atomic|atomic\\+random|random|file)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-startingwfc.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tqr.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tqr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tqr.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-tqr.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-real_space.namelist-electrons.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(real_space)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-real_space.namelist-electrons.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-real_space.namelist-electrons.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}

--- a/syntaxes/pwx-fcp-tags.json
+++ b/syntaxes/pwx-fcp-tags.json
@@ -1,0 +1,188 @@
+{
+    "scopeName": "pwx-fcp-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-fcp.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-fcp_mu.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_dynamics.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_conv_thr.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_ndiis.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_mass.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_velocity.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_temperature.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_tempw.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_tolp.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_delta_t.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-fcp_nraise.namelist-fcp.pwx"
+        },
+        {
+            "include": "#tag-freeze_all_atoms.namelist-fcp.pwx"
+        }
+    ],
+    "repository": {
+        "tag-fcp_mu.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_mu)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_mu.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_mu.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_dynamics.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_dynamics)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_dynamics.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(bfgs|newton|damp|lm|velocity\\-verlet|verlet)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-fcp_dynamics.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_conv_thr.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_conv_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_conv_thr.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_conv_thr.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_ndiis.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_ndiis)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_ndiis.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_ndiis.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_mass.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_mass)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_mass.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_mass.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_velocity.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_velocity)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_velocity.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_velocity.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_temperature.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_temperature)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_temperature.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(rescaling|rescale\\-v|rescale\\-T|reduce\\-T|berendsen|andersen|initial|not_controlled)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-fcp_temperature.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_tempw.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_tempw)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_tempw.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_tempw.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_tolp.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_tolp)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_tolp.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_tolp.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_delta_t.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_delta_t)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_delta_t.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_delta_t.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fcp_nraise.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fcp_nraise)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fcp_nraise.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fcp_nraise.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-freeze_all_atoms.namelist-fcp.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(freeze_all_atoms)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-freeze_all_atoms.namelist-fcp.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-freeze_all_atoms.namelist-fcp.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}

--- a/syntaxes/pwx-ions-tags.json
+++ b/syntaxes/pwx-ions-tags.json
@@ -1,0 +1,383 @@
+{
+    "scopeName": "pwx-ions-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-ions.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-ion_positions.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-ion_velocities.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-ion_dynamics.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-pot_extrapolation.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-wfc_extrapolation.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-remove_rigid_rot.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-ion_temperature.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-tempw.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-tolp.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-delta_t.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-nraise.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-refold_pos.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-upscale.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-bfgs_ndim.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-trust_radius_max.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-trust_radius_min.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-trust_radius_ini.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-w_1.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-w_2.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_alpha_init.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_falpha.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_nmin.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_f_inc.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_f_dec.namelist-ions.pwx"
+        },
+        {
+            "include": "#tag-fire_dtmax.namelist-ions.pwx"
+        }
+    ],
+    "repository": {
+        "tag-ion_positions.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ion_positions)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ion_positions.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(default|from_input)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ion_positions.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ion_velocities.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ion_velocities)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ion_velocities.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(default|from_input)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ion_velocities.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ion_dynamics.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ion_dynamics)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ion_dynamics.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(bfgs|damp|fire|verlet|langevin|langevin\\-smc|beeman)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ion_dynamics.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-pot_extrapolation.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(pot_extrapolation)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-pot_extrapolation.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(none|atomic|first_order|second_order)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-pot_extrapolation.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-wfc_extrapolation.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(wfc_extrapolation)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-wfc_extrapolation.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(none|first_order|second_order)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-wfc_extrapolation.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-remove_rigid_rot.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(remove_rigid_rot)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-remove_rigid_rot.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-remove_rigid_rot.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ion_temperature.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ion_temperature)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ion_temperature.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(rescaling|rescale\\-v|rescale\\-T|reduce\\-T|berendsen|andersen|svr|initial|not_controlled)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ion_temperature.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tempw.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tempw)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tempw.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-tempw.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tolp.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tolp)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tolp.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-tolp.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-delta_t.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(delta_t)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-delta_t.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-delta_t.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nraise.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nraise)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nraise.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nraise.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-refold_pos.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(refold_pos)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-refold_pos.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-refold_pos.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-upscale.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(upscale)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-upscale.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-upscale.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-bfgs_ndim.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(bfgs_ndim)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-bfgs_ndim.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-bfgs_ndim.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-trust_radius_max.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(trust_radius_max)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-trust_radius_max.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-trust_radius_max.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-trust_radius_min.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(trust_radius_min)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-trust_radius_min.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-trust_radius_min.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-trust_radius_ini.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(trust_radius_ini)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-trust_radius_ini.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-trust_radius_ini.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-w_1.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(w_1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-w_1.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-w_1.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-w_2.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(w_2)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-w_2.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-w_2.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_alpha_init.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_alpha_init)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_alpha_init.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_alpha_init.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_falpha.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_falpha)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_falpha.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_falpha.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_nmin.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_nmin)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_nmin.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_nmin.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_f_inc.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_f_inc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_f_inc.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_f_inc.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_f_dec.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_f_dec)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_f_dec.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_f_dec.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fire_dtmax.namelist-ions.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fire_dtmax)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fire_dtmax.namelist-ions.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fire_dtmax.namelist-ions.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}

--- a/syntaxes/pwx-system-tags.json
+++ b/syntaxes/pwx-system-tags.json
@@ -1,0 +1,1678 @@
+{
+    "scopeName": "pwx-system-tags.injection",
+    "injectionSelector": "L:entity.name.tag.content.namelist-system.pwx.espresso-in",
+    "patterns": [
+        {
+            "include": "#tag-ibrav.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-celldm.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-A.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-B.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-C.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-cosAB.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-cosAC.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-cosBC.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nat.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ntyp.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nbnd.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-tot_charge.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-starting_charge.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-tot_magnetization.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-starting_magnetization.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ecutwfc.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ecutrho.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ecutfock.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr1.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr2.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr3.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr1s.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr2s.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nr3s.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nosym.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nosym_evc.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-noinv.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-no_t_rev.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-force_symmorphic.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-use_all_frac.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-occupations.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-one_atom_occupations.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-starting_spin_angle.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-degauss.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-smearing.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nspin.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-noncolin.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ecfixed.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-qcutz.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-q2sigma.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-input_dft.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ace.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-exx_fraction.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-screening_parameter.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-exxdiv_treatment.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-x_gamma_extrapolation.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ecutvcut.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nqx1.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nqx2.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-nqx3.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-localization_thr.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lda_plus_u.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lda_plus_u_kind.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_U.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_J0.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_V.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_alpha.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_beta.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_J.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-starting_ns_eigenvalue.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-U_projection_type.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-Hubbard_parameters.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-dmft.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-dmft_prefix.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ensemble_energies.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-edir.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-emaxpos.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-eopreg.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-eamp.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-angle1.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-angle2.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lforcet.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-constrained_magnetization.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-fixed_magnetization.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lambda.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-report.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lspinorb.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-assume_isolated.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-esm_bc.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-esm_w.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-esm_efield.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-esm_nfit.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-lgcscf.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-gcscf_mu.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-gcscf_conv_thr.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-gcscf_beta.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-vdw_corr.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-london.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-london_s6.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-london_c6.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-london_rvdw.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-london_rcut.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-dftd3_version.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-dftd3_threebody.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ts_vdw_econv_thr.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-ts_vdw_isolated.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-xdm.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-xdm_a1.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-xdm_a2.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-space_group.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-uniqueb.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-origin_choice.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-rhombohedral.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-zgate.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-relaxz.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-block.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-block_1.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-block_2.namelist-system.pwx"
+        },
+        {
+            "include": "#tag-block_height.namelist-system.pwx"
+        }
+    ],
+    "repository": {
+        "tag-ibrav.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ibrav)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ibrav.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(0|1|2|\\-?3|4|\\-?5|6|7|8|\\-?91?|10|11|\\-?12|\\-?13|14)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.bravais-type.tag-ibrav.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-celldm.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(celldm\\()([1-6])(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-celldm.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "entity.other.attribute.tag-celldm.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-celldm.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-celldm.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-A.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(A|a)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-A.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-A.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-B.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(B|b)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-B.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-B.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-C.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(C|c)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-C.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-C.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-cosAB.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cosAB)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cosAB.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-cosAB.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-cosAC.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cosAC)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cosAC.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-cosAC.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-cosBC.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(cosBC)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-cosBC.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-cosBC.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nat.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nat)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nat.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nat.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ntyp.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ntyp)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ntyp.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ntyp.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nbnd.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nbnd)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nbnd.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nbnd.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tot_charge.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tot_charge)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tot_charge.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-tot_charge.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-starting_charge.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(starting_charge\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-starting_charge.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-starting_charge.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-starting_charge.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-starting_charge.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-tot_magnetization.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(tot_magnetization)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-tot_magnetization.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-tot_magnetization.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-starting_magnetization.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(starting_magnetization\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-starting_magnetization.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-starting_magnetization.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-starting_magnetization.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-starting_magnetization.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ecutwfc.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ecutwfc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ecutwfc.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ecutwfc.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ecutrho.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ecutrho)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ecutrho.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ecutrho.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ecutfock.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ecutfock)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ecutfock.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ecutfock.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr1.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr1.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr1.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr2.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr2)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr2.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr2.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr3.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr3.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr3.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr1s.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr1s)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr1s.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr1s.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr2s.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr2s)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr2s.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr2s.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nr3s.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nr1s)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nr3s.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nr3s.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nosym.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nosym)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nosym.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-nosym.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nosym_evc.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nosym_evc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nosym_evc.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-nosym_evc.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-noinv.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(noinv)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-noinv.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-noinv.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-no_t_rev.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(no_t_rev)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-no_t_rev.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-no_t_rev.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-force_symmorphic.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(force_symmorphic)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-force_symmorphic.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-force_symmorphic.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-use_all_frac.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(use_all_frac)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-use_all_frac.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-use_all_frac.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-occupations.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(occupations)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-occupations.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(smearing|tetrahedra|tetrahedra_lin|tetrahedra_opt|fixed|from_input)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-occupations.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-one_atom_occupations.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(one_atom_occupations)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-one_atom_occupations.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-one_atom_occupations.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-starting_spin_angle.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(starting_spin_angle)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-starting_spin_angle.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-starting_spin_angle.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-degauss.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(degauss)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-degauss.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-degauss.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-smearing.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(smearing)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-smearing.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(gaussian|gauss|methfessel\\-paxton|m\\-?p|marzari-vanderbilt|cold|m\\-?v|fermi-dirac|f\\-?d)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-smearing.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nspin.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nspin)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nspin.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(1|2|4)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-nspin.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-noncolin.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(noncolin)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-noncolin.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-noncolin.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ecfixed.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ecfixed)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ecfixed.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ecfixed.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-qcutz.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(qcutz)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-qcutz.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-qcutz.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-q2sigma.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(q2sigma)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-q2sigma.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-q2sigma.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-input_dft.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(input_dft)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-input_dft.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-input_dft.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ace.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ace)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ace.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ace.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-exx_fraction.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(exx_fraction)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-exx_fraction.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-exx_fraction.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-screening_parameter.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(screening_parameter)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-screening_parameter.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-screening_parameter.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-exxdiv_treatment.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(exxdiv_treatment)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-exxdiv_treatment.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(gygi\\-baldereschi|vcut_spherical|vcut_ws|none)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-exxdiv_treatment.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-x_gamma_extrapolation.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(x_gamma_extrapolation)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-x_gamma_extrapolation.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-x_gamma_extrapolation.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ecutvcut.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ecutvcut)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ecutvcut.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ecutvcut.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nqx1.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nqx1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nqx1.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nqx1.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nqx2.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nqx2)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nqx2.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nqx2.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-nqx3.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(nqx3)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-nqx3.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-nqx3.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-localization_thr.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(localization_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-localization_thr.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-localization_thr.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lda_plus_u.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lda_plus_u)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lda_plus_u.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lda_plus_u.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lda_plus_u_kind.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lda_plus_u_kind)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lda_plus_u_kind.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(0|1|2)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lda_plus_u_kind.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_U.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_U\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_U.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-Hubbard_U.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-Hubbard_U.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_U.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_J0.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_J0\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_J0.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-Hubbard_J0.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-Hubbard_J0.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_J0.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_V.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_V\\()(\\d+)(\\,)(\\d+)(\\,)([1-4])(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_V.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.na.tag-Hubbard_V.namelist-system.pwx.espresso-in" },
+                    "5": { "name": "constant.numeric.nb.tag-Hubbard_V.namelist-system.pwx.espresso-in" },
+                    "7": { "name": "entity.other.attribute.k.tag-Hubbard_V.namelist-system.pwx.espresso-in" },
+                    "8": { "name": "variable.parameter.declaration.tag-Hubbard_V.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_V.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_alpha.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_alpha\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_alpha.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-Hubbard_alpha.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-Hubbard_alpha.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_alpha.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_beta.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_beta\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_beta.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-Hubbard_beta.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-Hubbard_beta.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_beta.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_J.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_J\\()([1-3])(\\,)(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_J.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "entity.other.attribute.i.tag-Hubbard_J.namelist-system.pwx.espresso-in" },
+                    "5": { "name": "constant.numeric.ityp.tag-Hubbard_J.namelist-system.pwx.espresso-in" },
+                    "6": { "name": "variable.parameter.declaration.tag-Hubbard_J.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-Hubbard_J.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-starting_ns_eigenvalue.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(starting_ns_eigenvalue\\()(\\d+)(\\,)(\\d+)(\\,)([1-4])(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.m.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" },
+                    "5": { "name": "constant.numeric.ispin.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" },
+                    "7": { "name": "constant.numeric.ityp.k.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" },
+                    "8": { "name": "variable.parameter.declaration.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-starting_ns_eigenvalue.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-U_projection_type.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(U_projection_type)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-U_projection_type.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(atomic|ortho\\-atomic|norm\\-atomic|file|pesudo)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-U_projection_type.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-Hubbard_parameters.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(Hubbard_parameters)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-Hubbard_parameters.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(input|file)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-Hubbard_parameters.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dmft.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dmft)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dmft.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-dmft.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dmft_prefix.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dmft_prefix)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dmft_prefix.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(.*)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "string.quoted.tag-dmft_prefix.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ensemble_energies.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ensemble_energies)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ensemble_energies.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ensemble_energies.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-edir.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(edir)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-edir.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)([1-3])(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.latt_vector.tag-edir.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-emaxpos.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(emaxpos)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-emaxpos.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-emaxpos.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-eopreg.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(eopreg)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-eopreg.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-eopreg.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-eamp.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(eamp)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-eamp.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-eamp.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-angle1.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(angle1\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-angle1.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-angle1.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-angle1.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-angle1.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-angle2.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(angle2\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-angle2.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-angle2.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-angle2.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-angle2.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lforcet.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lforcet)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lforcet.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lforcet.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-constrained_magnetization.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(constrained_magnetization)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-constrained_magnetization.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(nonte|total|atomic|total direction|atomic direction)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-constrained_magnetization.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-fixed_magnetization.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(fixed_magnetization\\()([1-3]])(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-fixed_magnetization.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "entity.other.attribute.vector.tag-fixed_magnetization.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-fixed_magnetization.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-fixed_magnetization.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lambda.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lambda)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lambda.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-lambda.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-report.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(report)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-report.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-1|\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-report.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lspinorb.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lspinorb)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lspinorb.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lspinorb.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-assume_isolated.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(assume_isolated)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-assume_isolated.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(none|makov\\-payne|m\\-?p|martyna\\-tuckerman|m\\-?t|esm|2D)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-assume_isolated.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-esm_bc.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(esm_bc)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-esm_bc.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(?i)(pbc|bc1|bc2|bc3)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-esm_bc.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-esm_w.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(esm_w)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-esm_w.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-esm_w.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-esm_efield.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(esm_efield)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-esm_efield.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-esm_efield.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-esm_nfit.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(esm_nfit)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-esm_nfit.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-esm_nfit.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-lgcscf.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(lgcscf)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-lgcscf.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-lgcscf.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-gcscf_mu.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(gcscf_mu)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-gcscf_mu.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-gcscf_mu.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-gcscf_conv_thr.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(gcscf_conv_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-gcscf_conv_thr.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-gcscf_conv_thr.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-gcscf_beta.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(gcscf_beta)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-gcscf_beta.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-gcscf_beta.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-vdw_corr.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(vdw_corr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-vdw_corr.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\'(grimme\\-d[23]|Grimme\\-D[23]|dft\\-d3?|DFT\\-D3?|TS|ts|ts\\-vd[wW]|tkatchenko\\-scheffler|mbd_vdw|many\\-body dispersion|XDM|xdm)\\')(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-vdw_corr.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-london.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(london)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-london.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-london.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-london_s6.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(london_s6)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-london_s6.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-london_s6.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-london_c6.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(london_c6\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-london_c6.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-london_c6.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-london_c6.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-london_c6.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-london_rvdw.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(london_rvdw\\()(\\d+)(\\))(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-london_rvdw.namelist-system.pwx.espresso-in" },
+                    "3": { "name": "constant.numeric.i_ntyp.tag-london_rvdw.namelist-system.pwx.espresso-in" },
+                    "4": { "name": "variable.parameter.declaration.tag-london_rvdw.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-london_rvdw.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-london_rcut.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(london_rcut)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-london_rcut.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-london_rcut.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dftd3_version.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dftd3_version)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dftd3_version.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)([2-6])(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-dftd3_version.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-dftd3_threebody.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(dftd3_threebody)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-dftd3_threebody.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-dftd3_threebody.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ts_vdw_econv_thr.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ts_vdw_econv_thr)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ts_vdw_econv_thr.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-ts_vdw_econv_thr.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-ts_vdw_isolated.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(ts_vdw_isolated)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-ts_vdw_isolated.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-ts_vdw_isolated.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-xdm.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(xdm)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-xdm.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-xdm.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-xdm_a1.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(xdm_a1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-xdm_a1.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-xdm_a1.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-xdm_a2.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(xdm_a2)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-xdm_a2.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-xdm_a2.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-space_group.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(space_group)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-space_group.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-space_group.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-uniqueb.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(uniqueb)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-uniqueb.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-uniqueb.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-origin_choice.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(origin_choice)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-origin_choice.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-origin_choice.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-rhombohedral.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(rhombohedral)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-rhombohedral.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-rhombohedral.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-zgate.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(zgate)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-zgate.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-zgate.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-relaxz.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(relaxz)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-relaxz.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-relaxz.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-block.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(block)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-block.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\.(?i)(true|false)\\.)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "entity.other.attribute.tag-block.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-block_1.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(block_1)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-block_1.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-block_1.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-block_2.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(block_2)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-block_2.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-block_2.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        },
+        "tag-block_height.namelist-system.pwx": {
+            "patterns": [{
+                "begin": "(^\\s*)(block_height)(?=[\\s\\=])",
+                "beginCaptures": {
+                    "2": { "name": "variable.parameter.declaration.tag-block_height.namelist-system.pwx.espresso-in" }
+                },
+                "end": "(\\s*\\=\\s*)(\\-?\\d*\\.?\\d*(?i)[de]?[\\-\\+]?\\d*)(\\s*,?\\s*)$",
+                "endCaptures": {
+                    "2": { "name": "constant.numeric.tag-block_height.namelist-system.pwx.espresso-in" }
+                }
+            }]
+        }
+    }
+}


### PR DESCRIPTION
Value aware highlighting for pw.x input files.
Conventions are:
1. Namelists and Cards header --> entity.name.tags
2. Tags in Namelists --> variable.parameter
3. Strings and values that are restricted to some specific words or numbers --> entity.other.attribute
4. Numeric values --> constant.numeric
5. Strings --> string

NOTE: Exception for "input_dft" tag, the input keyword is considered as (unrestricted)string because of too many keywords in funct.f90 (see pw.x legal documentation).